### PR TITLE
Autodetect output directory of VS code counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,16 @@
         }
       ]
     },
+    "configuration": {
+      "title": "CodeViz Stats",
+      "properties": {
+        "CodeViz.autoDetectCounterOutputPath": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable this to get the Visual Studio Code Counter (VSCC) output path setting automatically when running \"CodeViz: Show statistics\".  Disable this to use the default VSCC output path \"%workspaceFolder%/.VSCodeCounter\"."
+        }
+      }
+    },
     "commands": [
       {
         "command": "CodeViz.show",

--- a/src/data/vscc_datasource.ts
+++ b/src/data/vscc_datasource.ts
@@ -1,22 +1,49 @@
-import { Uri } from "vscode";
-
+import { Uri, workspace } from 'vscode';
+import { isAbsolute, join, normalize } from 'path';
 export class VSCCDataSource {
     public data: object = Object;
     public folder: String = '';
     public date: String = '';
     private _dataFolderUri: Uri;
 
-    public constructor(wsUri: Uri, targetDir: Uri) {
-        this._dataFolderUri = Uri.joinPath(wsUri, '.VSCodeCounter');;
+    public constructor(wsUri: Uri) {
+        this._dataFolderUri = this._getVSCCDataFolder(wsUri);
         this._selectDataSourceFolder(wsUri);
         this._readDataSource();
     }
 
-	private _selectDataSourceFolder(wsUri: Uri) {
-		let result: {date: String, path: String}[] = [];
-		const fs = require('fs');
-		const dirPath = fs.readdirSync(this._dataFolderUri.fsPath);
-		dirPath.map((item: String) => {
+    private _getVSCCDataFolder(wsUri: Uri): Uri {
+        const defaultPath = '.VSCodeCounter';
+        const autoPathDetectEnabled = workspace
+            .getConfiguration('CodeViz')
+            .get<boolean>('autoDetectCounterOutputPath');
+        if (autoPathDetectEnabled) {
+            return this._generateVSCCUri(wsUri, defaultPath);
+        } else {
+            return Uri.joinPath(wsUri, defaultPath);
+        }
+    }
+
+    private _generateVSCCUri(wsUri: Uri, defaultPath: string): Uri {
+        let counterOutputDir = workspace
+            .getConfiguration('VSCodeCounter')
+            .get<string>('outputDirectory');
+
+        if (counterOutputDir) {
+            if (isAbsolute(counterOutputDir)) {
+                return Uri.file(counterOutputDir);
+            } else {
+                return Uri.joinPath(wsUri, counterOutputDir);
+            }
+        } else {
+            return Uri.joinPath(wsUri, defaultPath);
+        }
+    }
+    private _selectDataSourceFolder(wsUri: Uri) {
+        let result: { date: String; path: String }[] = [];
+        const fs = require('fs');
+        const dirPath = fs.readdirSync(this._dataFolderUri.fsPath);
+        dirPath.map((item: String) => {
             let path = Uri.joinPath(this._dataFolderUri, item.valueOf());
             result.push({date: item, path: path.fsPath});
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export function activate(context: ExtensionContext) {
                     let source: VSCCDataSource;
                     if (targetDir == undefined)
                         targetDir = wsPath;
-                    source = new VSCCDataSource(wsPath, targetDir);
+                    source = new VSCCDataSource(wsPath);
                     if (source.data != undefined) {
                         let data = new VSCCDataPrep();
                         data.makeDataTable(source.data);


### PR DESCRIPTION
Fixes #6 

Implements feature to auto detect the output directory of VSCC if one is set in the user's workspace/global VSCC settings.  Provides configuration option in VS code to turn feature off and revert to only using the default directory as it was without this feature.  Auto detection is enabled by default.